### PR TITLE
boe td4320: 64 Hz test and disabled ESD check + ARM: dts: Use sync pulses for boe td4320 panel

### DIFF
--- a/arch/arm/boot/dts/qcom/dsi-panel-boe-td4320-1080p-video.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-boe-td4320-1080p-video.dtsi
@@ -38,7 +38,7 @@
 		qcom,mdss-dsi-underflow-color = <0xff>;
 		qcom,mdss-dsi-border-color = <0>;
 		qcom,mdss-dsi-h-sync-pulse = <0>;
-		qcom,mdss-dsi-traffic-mode = "burst_mode";
+		qcom,mdss-dsi-traffic-mode = "non_burst_sync_pulse";
 		qcom,mdss-dsi-bllp-eof-power-mode;
 		qcom,mdss-dsi-bllp-power-mode;
 		qcom,mdss-dsi-lane-0-state;

--- a/arch/arm/boot/dts/qcom/dsi-panel-boe-td4320-1080p-video.dtsi
+++ b/arch/arm/boot/dts/qcom/dsi-panel-boe-td4320-1080p-video.dtsi
@@ -16,7 +16,7 @@
 		qcom,mdss-dsi-panel-name = "boe td4320 fhdplus video mode dsi panel";
 		qcom,mdss-dsi-panel-controller = <&mdss_dsi0>;
 		qcom,mdss-dsi-panel-type = "dsi_video_mode";
-		qcom,mdss-dsi-panel-framerate = <60>;
+		qcom,mdss-dsi-panel-framerate = <64>;
 		qcom,mdss-dsi-virtual-channel-id = <0>;
 		qcom,mdss-dsi-stream = <0>;
 		qcom,mdss-dsi-panel-width = <1080>;
@@ -188,8 +188,6 @@
 		qcom,mdss-dsi-reset-sequence = <1 1>, <0 5>, <1 30>;
 		qcom,mdss-dsi-tx-eot-append;
 		qcom,mdss-dsi-post-init-delay = <1>;
-
-		qcom,esd-check-enabled;
 		qcom,mdss-dsi-panel-status-command = [06 01 00 01 05 00 01 0A];
 		qcom,mdss-dsi-panel-status-command-state = "dsi_hs_mode";
 		qcom,mdss-dsi-panel-status-check-mode = "reg_read";


### PR DESCRIPTION
i'm retarded, qcom,mdss-dsi-panel-timings are stock